### PR TITLE
Fixed a typo

### DIFF
--- a/src/components/modals/NewServerModal.vue
+++ b/src/components/modals/NewServerModal.vue
@@ -22,7 +22,7 @@
 
 		<div id="join-server" v-if="whichForm == 'join'">
 			<div class="form-element-wrapper">
-				<label>Enter Inivite Token:</label>
+				<label>Enter Invite Token:</label>
 				<input v-model="token" type="text">
 			</div>
 			<p v-if="notice.message.length"


### PR DESCRIPTION
Attempting to join a server showed prompted the user "Enter Inivite Token:"
Now prompts "Enter Invite Token:"